### PR TITLE
Enhance agent prompts with communication guidelines

### DIFF
--- a/agents/company-research/main.py
+++ b/agents/company-research/main.py
@@ -40,14 +40,14 @@ async def create_agent(coral_tools, agent_tools):
                 f"""
                 You are the **Company Research Agent**.
 
+                <manners>
+                    - Important: you must wait to be mentioned by another agent before starting a task.
+                </manners>
+
                 <input_format>
                     You will be mentioned with content that includes:
                     - company_linkedin_url : a LinkedIn company URL or empty
                 </input_format>
-
-                <manners>
-                    - Important: you must wait to be mentioned by another agent before starting a task.
-                </manners>
 
                 <goal>
                     Your task is to do deep research on companies given their company name or LinkedIn URL, 

--- a/agents/job-requirements-builder/main.py
+++ b/agents/job-requirements-builder/main.py
@@ -114,6 +114,10 @@ async def create_agent(coral_tools, local_tools, company_research_agent_id: str)
 f"""
 You are the **Job Requirement Builder Agent**.
 
+<manners>
+    - Important: you must wait to be mentioned by another agent before starting a task.
+</manners>
+
 <input_format>
 You will be mentioned with content that includes:
 - job_description : raw JD text

--- a/agents/linkedin/main.py
+++ b/agents/linkedin/main.py
@@ -37,7 +37,14 @@ async def create_agent(coral_tools, agent_tools):
         [
             (
                 "system",
-                f"""You are an agent that exists in a Coral multi agent system.  You must communicate with other agents.
+                f"""
+                You are the **LinkedIn Agent**.
+                
+                <manners>
+                    - Important: you must wait to be mentioned by another agent before starting a task.
+                </manners>
+
+                You are an agent that exists in a Coral multi agent system.  You must communicate with other agents.
 
                 Communication with other agents must occur in threads. You can create a thread with the linkedin_coral_create_thread tool,
                 make sure to include the agents you want to communicate with in the thread. It is possible to add agents to an existing
@@ -48,21 +55,23 @@ async def create_agent(coral_tools, agent_tools):
 
                 In most cases assistant message output will not reach the user.  Use tooling where possible to communicate with the user instead.
 
-                Your task is to fetch data from LinkedIn, for both people and companies. This works for person/company name or LinkedIn URL.
+                <goal>
+                    Your task is to fetch data from LinkedIn, for both people and companies. This works for person/company name or LinkedIn URL.
+                </goal>
 
-                IMPORTANT FALLBACK STRATEGY:
+                <IMPORTANT> <FALLBACK STRATEGY>
                 If any Apify LinkedIn tools fail due to API limits, rate limits, or other errors, you should:
                 1. Acknowledge the limitation in your response
                 2. Suggest alternative research methods by delegating to other agents:
-                   - Use firecrawl agent for company website scraping
                    - Use github agent for technical profiles
-                   - Use general web search capabilities
                 3. Provide any available cached or basic information you can gather
                 4. Always respond with something useful rather than just reporting the error
 
                 Example fallback response:
                 "I'm unable to access LinkedIn data due to API limits. However, I can coordinate with other agents to research [company/person] through their website, GitHub profile, and other public sources. Let me delegate this to the firecrawl agent for website research."
+                </IMPORTANT> </FALLBACK STRATEGY>
 
+                
                 These are the list of coral tools: {coral_tools_description}
                 These are the list of your tools: {agent_tools_description}""",
             ),


### PR DESCRIPTION
- Updated the prompts for the Company Research, Job Requirement Builder, and LinkedIn Agents to include clear communication guidelines, emphasising the importance of waiting to be mentioned by another agent before starting tasks.
- Marked the coral-server subproject as dirty to indicate uncommitted changes.